### PR TITLE
Missing libm for rrdq by Dan Molik <dan@danmolik.com> 2015-07-30

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ LDADD = -lvigor
 
 bin_PROGRAMS = rrdq
 rrdq_SOURCES = src/rrdq.c
-rrdq_LDADD   = -lrrd
+rrdq_LDADD   = -lrrd -lm
 
 collectorsdir=$(libdir)/bolo/collectors
 dist_collectors_SCRIPTS  =

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,10 @@ AC_PROG_CC
 
 AC_HAVE_LIBRARY(vigor,,    AC_MSG_ERROR(Missing libvigor - see http://github.com/filefrog/libvigor))
 
+AC_HAVE_LIBRARY(m,,    AC_MSG_ERROR(Missing libm - see https://sourceware.org/glibc/wiki/libm))
+AC_CHECK_LIB([m],[sqrt])
+AC_CHECK_LIB([m],[floor])
+
 build_ALL=auto
 AC_ARG_WITH([all-collectors],
 	[AS_HELP_STRING([--with-all-collectors],


### PR DESCRIPTION
Failed to compile rrdq on Gentoo with GCC-4.9.2 and GLIBC-2.20 with
error:

/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.2/../../../../x86_64-pc-linux-gnu/bin/ld:
src/rrdq.o: undefined reference to symbol 'floor@@GLIBC_2.2.5'
/lib64/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:560: recipe for target 'rrdq' failed
make: *** [rrdq] Error 1